### PR TITLE
Add Spring Boot entry point and database configuration

### DIFF
--- a/src/main/java/com/geektracker/api/GeekTrackerApiApplication.java
+++ b/src/main/java/com/geektracker/api/GeekTrackerApiApplication.java
@@ -1,0 +1,11 @@
+package com.geektracker.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GeekTrackerApiApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GeekTrackerApiApplication.class, args);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,12 @@
 spring:
   application:
     name: geek-tracker-api
-
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    baseline-on-migrate: true


### PR DESCRIPTION
## Summary
- add GeekTrackerApiApplication with `@SpringBootApplication` entry point
- configure datasource, JPA, and Flyway properties in application.yml using environment variables

## Testing
- `gradle test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a7de455f88328a7826ad7e340c398