### PR TITLE
Add domain models, entities, and DTOs

### DIFF
--- a/src/main/java/com/geektracker/api/dto/CollectionResponse.java
+++ b/src/main/java/com/geektracker/api/dto/CollectionResponse.java
@@ -1,0 +1,14 @@
+package com.geektracker.api.dto;
+
+import com.geektracker.domain.model.Category;
+import java.util.List;
+
+public record CollectionResponse(
+        Long id,
+        String title,
+        Integer year,
+        Category category,
+        Double personalRating,
+        String imageUrl,
+        List<ItemResponse> items
+) {}

--- a/src/main/java/com/geektracker/api/dto/CreateCollectionRequest.java
+++ b/src/main/java/com/geektracker/api/dto/CreateCollectionRequest.java
@@ -1,0 +1,12 @@
+package com.geektracker.api.dto;
+
+import com.geektracker.domain.model.Category;
+import jakarta.validation.constraints.*;
+
+public record CreateCollectionRequest(
+        @NotBlank @Size(max = 255) String title,
+        @NotNull @Min(0) Integer year,
+        @NotNull Category category,
+        @NotNull @DecimalMin("0.0") @DecimalMax("5.0") Double personalRating,
+        @NotBlank String imageUrl
+) {}

--- a/src/main/java/com/geektracker/api/dto/CreateItemRequest.java
+++ b/src/main/java/com/geektracker/api/dto/CreateItemRequest.java
@@ -1,0 +1,12 @@
+package com.geektracker.api.dto;
+
+import com.geektracker.domain.model.Category;
+import jakarta.validation.constraints.*;
+
+public record CreateItemRequest(
+        @NotBlank @Size(max = 255) String title,
+        @NotNull @Min(0) Integer year,
+        @NotNull Category category,
+        @NotNull @DecimalMin("0.0") @DecimalMax("5.0") Double personalRating,
+        @NotBlank String imageUrl
+) {}

--- a/src/main/java/com/geektracker/api/dto/ItemResponse.java
+++ b/src/main/java/com/geektracker/api/dto/ItemResponse.java
@@ -1,0 +1,12 @@
+package com.geektracker.api.dto;
+
+import com.geektracker.domain.model.Category;
+
+public record ItemResponse(
+        Long id,
+        String title,
+        Integer year,
+        Category category,
+        Double personalRating,
+        String imageUrl
+) {}

--- a/src/main/java/com/geektracker/domain/model/Category.java
+++ b/src/main/java/com/geektracker/domain/model/Category.java
@@ -1,0 +1,8 @@
+package com.geektracker.domain.model;
+
+public enum Category {
+    VIDEO_GAMES,
+    BOOKS,
+    MOVIES,
+    RETRO_HARDWARE
+}

--- a/src/main/java/com/geektracker/domain/model/Collection.java
+++ b/src/main/java/com/geektracker/domain/model/Collection.java
@@ -1,0 +1,37 @@
+package com.geektracker.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "collections")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Collection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private Integer year;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private Double personalRating;
+
+    private String imageUrl;
+
+    @OneToMany(mappedBy = "collection", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Item> items = new ArrayList<>();
+}

--- a/src/main/java/com/geektracker/domain/model/Item.java
+++ b/src/main/java/com/geektracker/domain/model/Item.java
@@ -1,0 +1,35 @@
+package com.geektracker.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "items")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Item {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private Integer year;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private Double personalRating;
+
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+}


### PR DESCRIPTION
## Summary
- add Category enum in the domain model
- implement JPA entities Collection and Item with 1:N relationship
- add request and response DTOs for collections and items with validation annotations

## Testing
- `gradle build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a838b85d08328aa2541c826c7875f