### PR TITLE
feat: add JPA repositories for collections and items

### DIFF
--- a/src/main/java/com/geektracker/infra/repository/CollectionRepository.java
+++ b/src/main/java/com/geektracker/infra/repository/CollectionRepository.java
@@ -1,0 +1,13 @@
+package com.geektracker.infra.repository;
+
+import com.geektracker.domain.model.Collection;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CollectionRepository extends JpaRepository<Collection, Long> {
+
+    @EntityGraph(attributePaths = "items")
+    Optional<Collection> findById(Long id);
+}

--- a/src/main/java/com/geektracker/infra/repository/ItemRepository.java
+++ b/src/main/java/com/geektracker/infra/repository/ItemRepository.java
@@ -1,0 +1,11 @@
+package com.geektracker.infra.repository;
+
+import com.geektracker.domain.model.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findByCollectionId(Long collectionId);
+}


### PR DESCRIPTION
## Summary
- add CollectionRepository with Item relationship fetching via @EntityGraph
- add ItemRepository with query helper to load items by collection

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689df1001b488328a9df6675be7e4327