### PR TITLE
feat: add collection and item services

### DIFF
--- a/src/main/java/com/geektracker/api/mapper/CollectionMapper.java
+++ b/src/main/java/com/geektracker/api/mapper/CollectionMapper.java
@@ -1,0 +1,17 @@
+package com.geektracker.api.mapper;
+
+import com.geektracker.api.dto.CollectionResponse;
+import com.geektracker.api.dto.CreateCollectionRequest;
+import com.geektracker.domain.model.Collection;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = ItemMapper.class)
+public interface CollectionMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "items", ignore = true)
+    Collection toEntity(CreateCollectionRequest request);
+    CollectionResponse toResponse(Collection collection);
+    List<CollectionResponse> toResponseList(List<Collection> collections);
+}

--- a/src/main/java/com/geektracker/api/mapper/ItemMapper.java
+++ b/src/main/java/com/geektracker/api/mapper/ItemMapper.java
@@ -1,0 +1,17 @@
+package com.geektracker.api.mapper;
+
+import com.geektracker.api.dto.CreateItemRequest;
+import com.geektracker.api.dto.ItemResponse;
+import com.geektracker.domain.model.Item;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ItemMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "collection", ignore = true)
+    Item toEntity(CreateItemRequest request);
+    ItemResponse toResponse(Item item);
+    List<ItemResponse> toResponseList(List<Item> items);
+}

--- a/src/main/java/com/geektracker/domain/service/CollectionService.java
+++ b/src/main/java/com/geektracker/domain/service/CollectionService.java
@@ -1,0 +1,29 @@
+package com.geektracker.domain.service;
+
+import com.geektracker.api.dto.CollectionResponse;
+import com.geektracker.api.dto.CreateCollectionRequest;
+import com.geektracker.api.mapper.CollectionMapper;
+import com.geektracker.infra.repository.CollectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CollectionService {
+
+    private final CollectionRepository collectionRepository;
+    private final CollectionMapper collectionMapper;
+
+    public CollectionResponse createCollection(CreateCollectionRequest request) {
+        var collection = collectionMapper.toEntity(request);
+        var saved = collectionRepository.save(collection);
+        return collectionMapper.toResponse(saved);
+    }
+
+    public Page<CollectionResponse> listCollections(Pageable pageable) {
+        return collectionRepository.findAll(pageable)
+                .map(collectionMapper::toResponse);
+    }
+}

--- a/src/main/java/com/geektracker/domain/service/ItemService.java
+++ b/src/main/java/com/geektracker/domain/service/ItemService.java
@@ -1,0 +1,35 @@
+package com.geektracker.domain.service;
+
+import com.geektracker.api.dto.CreateItemRequest;
+import com.geektracker.api.dto.ItemResponse;
+import com.geektracker.api.mapper.ItemMapper;
+import com.geektracker.domain.model.Category;
+import com.geektracker.infra.repository.CollectionRepository;
+import com.geektracker.infra.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+    private final CollectionRepository collectionRepository;
+    private final ItemMapper itemMapper;
+
+    public ItemResponse addItemToCollection(Long collectionId, CreateItemRequest request) {
+        var collection = collectionRepository.findById(collectionId)
+                .orElseThrow(() -> new IllegalArgumentException("Collection not found"));
+        var item = itemMapper.toEntity(request);
+        item.setCollection(collection);
+        var saved = itemRepository.save(item);
+        return itemMapper.toResponse(saved);
+    }
+
+    public List<ItemResponse> getItems(Long collectionId, Category category, Integer year) {
+        var items = itemRepository.findByFilters(collectionId, category, year);
+        return itemMapper.toResponseList(items);
+    }
+}

--- a/src/main/java/com/geektracker/infra/repository/ItemRepository.java
+++ b/src/main/java/com/geektracker/infra/repository/ItemRepository.java
@@ -1,11 +1,19 @@
 package com.geektracker.infra.repository;
 
+import com.geektracker.domain.model.Category;
 import com.geektracker.domain.model.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     List<Item> findByCollectionId(Long collectionId);
+
+    @Query("SELECT i FROM Item i WHERE (:collectionId IS NULL OR i.collection.id = :collectionId) AND (:category IS NULL OR i.category = :category) AND (:year IS NULL OR i.year = :year)")
+    List<Item> findByFilters(@Param("collectionId") Long collectionId,
+                             @Param("category") Category category,
+                             @Param("year") Integer year);
 }


### PR DESCRIPTION
## Summary
- add MapStruct mappers for collections and items
- implement service layer for creating collections and managing items
- support item queries by collection, category or year

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689e1aa6bda88328af920d47070cf610